### PR TITLE
Newest Ubuntu updated default gcc to 13.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # ubuntu:latest points to the latest LTS
-ARG BASE_IMAGE=ubuntu:latest
+#ARG BASE_IMAGE=ubuntu:latest
+ARG BASE_IMAGE=ubuntu:22.04
 FROM $BASE_IMAGE
 
 # Install dependencies


### PR DESCRIPTION
This breaks the kokkos 3.7.01 build on petsc that's required by TCHEM. This dependency itself should be fixed, but for now just change the base image back so PR's can run testing