### PR TITLE
Disabling Arm64 for now (Temporary)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,7 +31,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ { runson: ARM64, id: -arm64 }, { runson: ubuntu-latest, id: -amd64 } ]
+        arch: [ { runson: ubuntu-latest, id: -amd64 } ]
+#        arch: [ { runson: ARM64, id: -arm64 }, { runson: ubuntu-latest, id: -amd64 } ] # disabling arm64 until we can figure out either new machines to run these on or wipe/ reset Matt's old ones -klb
     runs-on: ${{ matrix.arch.runson }}
 
     steps:
@@ -67,7 +68,8 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        arch: [ { runson: ARM64, id: -arm64 }, { runson: ubuntu-latest, id: -amd64 } ]
+        arch: [ { runson: ubuntu-latest, id: -amd64 } ] # disabling arm64 until we can figure out either new machines to run these on or wipe/ reset Matt's old ones -klb
+        #arch: [ { runson: ARM64, id: -arm64 }, { runson: ubuntu-latest, id: -amd64 } ]
 
     steps:
       - name: Set up Docker Buildx


### PR DESCRIPTION
The github runner machines for arm 64 went down and we are disabling these tests for now since we don't the passwords for the machines/ are unaware of which machines they were on.